### PR TITLE
Fix cover display issue of wechat-official-accounts

### DIFF
--- a/weread.py
+++ b/weread.py
@@ -397,6 +397,8 @@ if __name__ == "__main__":
             book = book.get("book")
             title = book.get("title")
             cover = book.get("cover")
+            if book.get("author") == "公众号" and book.get("cover").endswith("/0"):
+                cover += ".jpg"
             bookId = book.get("bookId")
             author = book.get("author")
             check(bookId)


### PR DESCRIPTION
There is an display issue that Cover display of wechat-official-accounts is empty

I found all the cove img of wechat-official-accounts is end with '/0' without '.jpg'

like `https://wx.qlogo.cn/mmhead/Q3auHgzwzM4yMleEhhGWPne68kmxPNkU76cyxZPoKcv20c4iaibY2bJg/0`

So I added the '.jpg' at the end of link of wechat-official-accounts cover

> ![image](https://github.com/malinkang/weread_to_notion/assets/25995001/08718cd8-c9d0-4c75-ad02-5165ea4ebe6d)

